### PR TITLE
Update Chainsword.xml

### DIFF
--- a/1.1/Defs/WeaponDefs/Chainsword.xml
+++ b/1.1/Defs/WeaponDefs/Chainsword.xml
@@ -19,6 +19,9 @@
     <stuffCategories>
       <li>Metallic</li>
     </stuffCategories>
+    <weaponTags>
+      <!-- ==== Insert corresponding weaponTag here ==== -->
+    </weaponTags>
     <statBases>
       <WorkToMake>13200</WorkToMake>
       <Mass>4.00</Mass>


### PR DESCRIPTION
The Chainsword lacks a weaponTag node. Since I don't know much about the lore of this particular mod, I just wrote a placeholder for it so that it's easier for you to add the corresponding field.

This was detected while making a compatibility patch to this mod.