### PR TITLE
Disabled generateAddictionGenes for RedHaze

### DIFF
--- a/Defs/ChemicalDefs/RedHazeChemical.xml
+++ b/Defs/ChemicalDefs/RedHazeChemical.xml
@@ -5,5 +5,6 @@
     <label>Red Haze</label>
     <addictionHediff>ReviaRaceRedHazeAddiction</addictionHediff>
     <canBinge>false</canBinge>
+    <generateAddictionGenes>false</generateAddictionGenes>
   </ChemicalDef>
 </Defs>


### PR DESCRIPTION
Having Biotech with Revia causes the game to attempt to generate anti-addiction genes for RedHaze, which will cause an NRE and texture error. I added an XML tag to RedHaze to disable the anti-addiction gene generation. 